### PR TITLE
Json recipes changes

### DIFF
--- a/src/main/resources/data/mekanism_weaponry/recipe/alien_paint_bucket.json
+++ b/src/main/resources/data/mekanism_weaponry/recipe/alien_paint_bucket.json
@@ -12,7 +12,7 @@
     "4": {"item":"minecraft:bucket"}
   },
   "result": {
-    "id": "mekanism_weaponry:alien_paint_bucket",
+    "item": "mekanism_weaponry:alien_paint_bucket",
     "count": 1
   }
 }

--- a/src/main/resources/data/mekanism_weaponry/recipe/railgun.json
+++ b/src/main/resources/data/mekanism_weaponry/recipe/railgun.json
@@ -9,11 +9,11 @@
     "1": {"item":"minecraft:anvil"},
     "2": {"item":"mekanism:ingot_refined_obsidian"},
     "3": {"item":"mekanism_weaponry:plasma_circuit"},
-    "4": {"item":"minecraft:breeze_rod"},
-    "5": {"tag":"c:ingots/steel"}
+    "4": {"item":"minecraft:blaze_rod"},
+    "5": {"tag":"forge:ingots/steel"}
   },
   "result": {
-    "id": "mekanism_weaponry:railgun",
+    "item": "mekanism_weaponry:railgun",
     "count": 1
   }
 }


### PR DESCRIPTION
Railgun recipe:
Breeze not able on Minecraft 1.20.1 replaced with blaze rod Alien paint bucket:
'A' symbol not defined in the key
changed 'ABC' to '123'